### PR TITLE
Implement cloudprovider.Get interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ The current focus is on implementing the [Karpenter cloudprovider interface][kci
 
 - [ ] `Create`
 - [ ] `Delete`
-- [ ] `Get`
+- [x] `Get`
 - [x] `List`
 - [x] `GetInstanceTypes`
+- [x] `GetSupportedNodeClasses`
 - [ ] `IsDrifted`
 - [x] `Name`
-- [x] `GetSupportedNodeClasses`
 
 ### Design topics
 

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -70,8 +70,26 @@ func (c CloudProvider) Delete(ctx context.Context, nodeClaim *v1beta1.NodeClaim)
 	return fmt.Errorf("not implemented")
 }
 
+// Get returns a NodeClaim for the Machine object with the supplied provider ID, or nil if not found.
 func (c CloudProvider) Get(ctx context.Context, providerID string) (*v1beta1.NodeClaim, error) {
-	return nil, fmt.Errorf("not implemented")
+	if len(providerID) == 0 {
+		return nil, fmt.Errorf("no providerID supplied to Get, cannot continue")
+	}
+
+	machine, err := c.machineProvider.Get(ctx, providerID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get Machine from machine provider: %w", err)
+	}
+	if machine == nil {
+		return nil, nil
+	}
+
+	nodeClaim, err := c.machineToNodeClaim(ctx, machine)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert Machine to NodeClaim in CloudProvider.Get: %w", err)
+	}
+
+	return nodeClaim, nil
 }
 
 // GetInstanceTypes enumerates the known Cluster API scalable resources to generate the list


### PR DESCRIPTION
this change set brings in the implementation for the `Get` method with an associated Machine provider implementation and tests.