### PR TITLE
add a getting started page to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ community to use this experiment for learning more about the design pattern, fea
 gaps, and areas for improvement. With the ultimate goal being a standard release
 cycle and production ready Karpenter Cluster API provider.
 
+For information about how to build and run the Karpenter Cluster API provider, please
+see the [Getting Started](docs/docs/getting-started.md) documentation.
+
 ### Design topics
 
 These are a few topics that are under active discussion by the

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1,0 +1,150 @@
+# Getting Started
+
+The process for running the Cluster API Karpenter provider contains several
+manual steps which must be performed before it will operate.
+
+## Building
+
+You will need to build the binary for the Karpenter Cluster API provider. To do
+this you will need a few prerequisities:
+
+* make
+* Go language 1.22+
+
+The next step is to clone this repository and navigate to the directory in
+a shell.
+
+This repository does not contain the necessary dependencies for building the controller,
+you will need to download them. The most convenient way to do this is by running the
+`vendor` target in the makefile. Type the following in your shell:
+
+```shell
+make vendor
+```
+
+After installing the dependencies, whether in the repo or your Go installation, you
+are ready to build the binary by typing the following in your shell:
+
+```shell
+make build
+```
+
+If there are no errors with the build, you should have a new directory and file in
+the repository: `bin/karpenter-cluster-controller`.
+
+This is the binary used for running the Karpenter Cluster API provider.
+
+## Running
+
+To run the Karpenter Cluster API provider you will need to configure the environment
+in which the binary is running (whether locally or in a Pod).
+
+### Kubernetes credential configuration
+
+The Karpenter binary assumes that it is running in an environment with a kubeconfig
+available, such as a Pod with a ServiceAccount. Functionally, this means that the
+environment variable `KUBECONFIG` should be set to the configuration file associated
+with the cluster that Karpenter will manage, e.g. where the Node, Pods, NodePools,
+NodeClasses, and NodeClaims will reside.
+
+Additionally, the Karpenter Cluster API provider needs to have a kubeconfig for the
+cluster where the Cluster API resources (Machines, MachineDeployments, etc.) will reside.
+Specify the kubeconfig for the Cluster API management cluster by setting the `--cluster-api-kubeconfig`
+command line flag.
+
+If you are using a joined cluster, where the Cluster API resources reside in the same
+cluster as the Karpenter resources, then you do not need to specify a separate kubeconfig
+using the command line flag.
+
+### Namespace configuration
+
+Karpenter wants to know the namespace where it will be running. This can be set with the
+environment variable `SYSTEM_NAMESPACE`.
+
+### Other configurations
+
+Please see the [Karpenter documentation on settings](https://karpenter.sh/docs/reference/settings/)
+for more configuration options.
+
+### Configuring the Karpenter resources
+
+To engage Karpenter in the cluster you will need to create a NodePool and a ClusterAPINodeClass at
+the minimum. For a deeper discussion of NodePools and NodeClasses, please see the
+[Karpenter documentation on concepts](https://karpenter.sh/docs/concepts/).
+
+The following are basic examples of the NodePool and ClusterAPINodeClass resources. In brief,
+the NodePool will match on any node that contains the well-known Kubernetes architecture label
+with a value of `amd64`. Further, the ClusterAPINodeClass will match any MachineDeployment
+which is participating in Karpenter (see Configuring the Cluster API resources).
+
+**Example NodePool**
+```yaml
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        - key: "kubernetes.io/arch"
+          operator: In
+          values: ["amd64"]
+      nodeClassRef:
+        apiVersion: karpenter.cluster.x-k8s.io/v1alpha1
+        kind: ClusterAPINodeClass
+        name: default
+```
+
+**Example ClusterAPINodeClass**
+```yaml
+apiVersion: karpenter.cluster.x-k8s.io/v1alpha1
+kind: ClusterAPINodeClass
+metadata:
+  name: default
+spec: {}
+```
+
+### Configuring the Cluster API resources
+
+The Karpenter Cluster API provider is designed to inspect Cluster API MachineDeployment
+resources to learn about the instance types it can create. There are a few things to
+adjust on your MachineDeployment resources to ensure that they will be properly assessed
+by Karpenter.
+
+1. Add the label `node.cluster.x-k8s.io/karpenter-member` to any MachineDeployment that should
+  be considered by Karpenter.
+1. Add the [scale from zero annotations](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210310-opt-in-autoscaling-from-zero.md#machineset-and-machinedeployment-annotations) to your MachineDeployments so that Karpenter knows
+  the shape of those instances.
+1. Add any labels that will be expected to be on created Nodes to your MachineDeployments using
+  either the [metadata propagation rules](https://cluster-api.sigs.k8s.io/developer/architecture/controllers/metadata-propagation.html?highlight=metadata%20pro#machinedeployment)
+  or the [scale from zero annotations](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210310-opt-in-autoscaling-from-zero.md#machineset-and-machinedeployment-annotations) for labels.
+
+For example, if a MachineDeployment will have instances with 128G of RAM, 16 CPU cores, and
+maximim Pod density of 100 pods, and it will be used with the example NodePool shown earlier it
+should have the following annotations:
+```yaml
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  annotations:
+    capacity.cluster-autoscaler.kubernetes.io/maxPods: "100"
+    capacity.cluster-autoscaler.kubernetes.io/memory: "128G"
+    capacity.cluster-autoscaler.kubernetes.io/cpu: "16"
+    capacity.cluster-autoscaler.kubernetes.io/labels: kubernetes.io/arch=amd64
+```
+
+Further, it should have the following label:
+```yaml
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    node.cluster.x-k8s.io/karpenter-member: ""
+```
+
+### Demonstration of Karpenter Cluster API provider
+
+This is a demo that was given during the Cluster API office hours meeting on 2024-08-07.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/BZz5ibGP7ZQ?si=0Ql-p6hJZHXYfmKB" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -8,3 +8,7 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+nav:
+  - Welcome: index.md
+  - Getting Started: getting-started.md
+  - Design: design.md


### PR DESCRIPTION
this change set adds a new page to the documentation site for getting started instructions, and it also updates the README with a pointer to that page.